### PR TITLE
send put request to content store

### DIFF
--- a/dags/process_elife_zip_dag.py
+++ b/dags/process_elife_zip_dag.py
@@ -129,7 +129,7 @@ def wrap_article_in_libero_xml_and_send_to_service(**context):
 
     # make PUT request to service
     response = requests.put(
-        SERVICE_URL,
+        '%s/items/%s/version/1' % (SERVICE_URL, article_id),
         data=etree.tostring(xml, xml_declaration=True, encoding='UTF-8'),
         headers={'content-type': 'application/xml'}
     )

--- a/dags/process_elife_zip_dag.py
+++ b/dags/process_elife_zip_dag.py
@@ -129,7 +129,7 @@ def wrap_article_in_libero_xml_and_send_to_service(**context):
 
     # make PUT request to service
     response = requests.put(
-        '%s/items/%s/version/1' % (SERVICE_URL, article_id),
+        '%s/items/%s/versions/1' % (SERVICE_URL, article_id),
         data=etree.tostring(xml, xml_declaration=True, encoding='UTF-8'),
         headers={'content-type': 'application/xml'}
     )

--- a/dags/process_elife_zip_dag.py
+++ b/dags/process_elife_zip_dag.py
@@ -86,7 +86,7 @@ def extract_archived_files_to_bucket(**context):
         return xml_path
 
 
-def prepare_jats_xml_for_libero(**context):
+def wrap_article_in_libero_xml_and_send_to_service(**context):
     # get xml path passed from previous task
     previous_task = get_previous_task_name(**context)
     xml_path = context['task_instance'].xcom_pull(task_ids=previous_task)
@@ -150,9 +150,9 @@ task_1 = python_operator.PythonOperator(
 )
 
 task_2 = python_operator.PythonOperator(
-    task_id='prepare_jats_xml_for_libero',
+    task_id='wrap_article_in_libero_xml_and_send_to_service',
     provide_context=True,
-    python_callable=prepare_jats_xml_for_libero,
+    python_callable=wrap_article_in_libero_xml_and_send_to_service,
     dag=dag
 )
 

--- a/dags/process_elife_zip_dag.py
+++ b/dags/process_elife_zip_dag.py
@@ -17,8 +17,8 @@ from airflow.utils import timezone
 from lxml import etree
 from lxml.builder import ElementMaker
 
-from aws import get_aws_connection, list_bucket_keys_iter
-from task_helpers import get_previous_task_name, get_return_value_from_previous_task
+from aws import get_aws_connection
+from task_helpers import get_previous_task_name
 
 ALLOWED_EXTENSIONS = {'.jpg', '.jpeg', '.pdf', '.xml'}
 
@@ -127,16 +127,10 @@ def prepare_jats_xml_for_libero(**context):
         root
     )
 
-    return etree.tostring(xml, xml_declaration=True, encoding='UTF-8')
-
-
-def send_put_request_to_service(**context):
-    return_value = get_return_value_from_previous_task(**context)
-    message = 'the previous task did not return data to send to %s' % SERVICE_URL
-    assert return_value is not None, message
+    # make PUT request to service
     response = requests.put(
         SERVICE_URL,
-        data=return_value,
+        data=etree.tostring(xml, xml_declaration=True, encoding='UTF-8'),
         headers={'content-type': 'application/xml'}
     )
     response.raise_for_status()
@@ -162,12 +156,4 @@ task_2 = python_operator.PythonOperator(
     dag=dag
 )
 
-task_3 = python_operator.PythonOperator(
-    task_id='send_put_request_to_service',
-    provide_context=True,
-    python_callable=send_put_request_to_service,
-    dag=dag
-)
-
 task_1.set_downstream(task_2)
-task_2.set_downstream(task_3)

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,3 +4,4 @@ pytest==4.5.0
 pytest-clarity==0.1.0a1
 pytest-mock==1.10.4
 pytest-socket==0.3.3
+requests-mock==1.6.0

--- a/tests/test_process_elife_zip_dag.py
+++ b/tests/test_process_elife_zip_dag.py
@@ -69,7 +69,7 @@ def test_wrap_article_in_libero_xml_and_send_to_service(context, s3_client, requ
     from dags import process_elife_zip_dag as pezd
     test_url = 'http://test-url.org'
     pezd.SERVICE_URL = test_url
-    session = requests_mock.put(test_url)
+    session = requests_mock.put('%s/items/00666/version/1' %  test_url)
 
     wrap_article_in_libero_xml_and_send_to_service(**context)
 

--- a/tests/test_process_elife_zip_dag.py
+++ b/tests/test_process_elife_zip_dag.py
@@ -7,7 +7,7 @@ from lxml import etree
 
 from dags.process_elife_zip_dag import (
     extract_archived_files_to_bucket,
-    prepare_jats_xml_for_libero,
+    wrap_article_in_libero_xml_and_send_to_service,
     ALLOWED_EXTENSIONS
 )
 
@@ -60,7 +60,7 @@ def test_extract_archived_files_to_bucket_only_uploads_allowed_file_types(contex
     assert all(Path(uf).suffix in ALLOWED_EXTENSIONS for uf in s3_client.uploaded_files)
 
 
-def test_prepare_jats_xml_for_libero(context, s3_client, requests_mock):
+def test_wrap_article_in_libero_xml_and_send_to_service(context, s3_client, requests_mock):
     # populate expected return value of previous task
     file_name = '/elife-666-vor-r1/elife-666.xml'
     ti = context['dag_run'].get_task_instances()[0]
@@ -71,7 +71,7 @@ def test_prepare_jats_xml_for_libero(context, s3_client, requests_mock):
     pezd.SERVICE_URL = test_url
     session = requests_mock.put(test_url)
 
-    prepare_jats_xml_for_libero(**context)
+    wrap_article_in_libero_xml_and_send_to_service(**context)
 
     request_data = bytes(session.last_request.text, encoding='UTF-8')
     xml = etree.parse(BytesIO(request_data))
@@ -94,8 +94,8 @@ def test_prepare_jats_xml_for_libero(context, s3_client, requests_mock):
     assert len(article.getchildren()) > 0
 
 
-def test_prepare_jats_xml_for_libero_raises_exception(context):
+def test_wrap_article_in_libero_xml_and_send_to_service_raises_exception(context):
     msg = 'path to xml document was not passed from task previous_task'
     with pytest.raises(AssertionError) as error:
-        prepare_jats_xml_for_libero(**context)
+        wrap_article_in_libero_xml_and_send_to_service(**context)
         assert str(error.value) == msg

--- a/tests/test_process_elife_zip_dag.py
+++ b/tests/test_process_elife_zip_dag.py
@@ -69,7 +69,7 @@ def test_wrap_article_in_libero_xml_and_send_to_service(context, s3_client, requ
     from dags import process_elife_zip_dag as pezd
     test_url = 'http://test-url.org'
     pezd.SERVICE_URL = test_url
-    session = requests_mock.put('%s/items/00666/version/1' %  test_url)
+    session = requests_mock.put('%s/items/00666/versions/1' %  test_url)
 
     wrap_article_in_libero_xml_and_send_to_service(**context)
 


### PR DESCRIPTION
As per https://github.com/libero/libero/issues/156 Adds a new task to `process_elife_zip_dag` to send a PUT request to the specified service (content store)